### PR TITLE
fix: append user specified arguments while launching the mariadb server

### DIFF
--- a/bitnami-utils-custom.sh
+++ b/bitnami-utils-custom.sh
@@ -1,5 +1,5 @@
 # MariaDB Utility functions
-PROGRAM_OPTIONS="--defaults-file=$BITNAMI_APP_DIR/my.cnf --log-error=$BITNAMI_APP_DIR/logs/mysqld.log --basedir=$BITNAMI_APP_DIR --datadir=$BITNAMI_APP_DIR/data --plugin-dir=$BITNAMI_APP_DIR/lib/plugin --user=$BITNAMI_APP_USER --socket=$BITNAMI_APP_DIR/tmp/mysql.sock --lower-case-table-names=1 $EXTRA_OPTIONS"
+PROGRAM_OPTIONS="--defaults-file=$BITNAMI_APP_DIR/my.cnf --log-error=$BITNAMI_APP_DIR/logs/mysqld.log --basedir=$BITNAMI_APP_DIR --datadir=$BITNAMI_APP_DIR/data --plugin-dir=$BITNAMI_APP_DIR/lib/plugin --user=$BITNAMI_APP_USER --socket=$BITNAMI_APP_DIR/tmp/mysql.sock --lower-case-table-names=1"
 
 initialize_database() {
     echo "==> Initializing MySQL database..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,9 @@ print_welcome_page
 if [ "${1:0:1}" = '-' ]; then
   EXTRA_OPTIONS="$@"
   set -- mysqld.bin
+elif [ "${1}" == "mysqld.bin" -o "${1}" == "$BITNAMI_APP_DIR/bin/mysqld.bin" ]; then
+  EXTRA_OPTIONS="${@:2}"
+  set -- mysqld.bin
 fi
 
 if [ ! "$(ls -A $BITNAMI_APP_VOL_PREFIX/conf)" ]; then
@@ -15,7 +18,7 @@ if [ ! "$(ls -A $BITNAMI_APP_VOL_PREFIX/conf)" ]; then
 fi
 
 if [ "$1" = 'mysqld.bin' ]; then
-  set -- $@ $PROGRAM_OPTIONS
+  set -- $@ $PROGRAM_OPTIONS $EXTRA_OPTIONS
   mkdir -p $BITNAMI_APP_DIR/tmp
   chown -R $BITNAMI_APP_USER:$BITNAMI_APP_USER $BITNAMI_APP_DIR/tmp || true
 


### PR DESCRIPTION
This is a fix for part 1 of #14. Not sure if the image expects users to start mariadb server as specified in part 2 of #14