### PR TITLE
remove the `/tmp/init_mysql.sql` at container startup

### DIFF
--- a/rootfs/etc/cont-init.d/01-bitnami-mariadb
+++ b/rootfs/etc/cont-init.d/01-bitnami-mariadb
@@ -2,6 +2,9 @@
 set -e
 source $BITNAMI_PREFIX/bitnami-utils.sh
 
+# remove initialization commands from last run
+rm -rf /tmp/init_mysql.sql
+
 if [ ! "$(ls -A $BITNAMI_APP_VOL_PREFIX/conf)" ]; then
   generate_conf_files
 fi

--- a/test.sh
+++ b/test.sh
@@ -155,6 +155,22 @@ cleanup_environment
   [[ "$output" =~ "mysqld.log" ]]
 }
 
+# https://github.com/bitnami/bitnami-docker-mariadb/issues/39
+@test "If host mounted, password and settings are preserved upon restart" {
+  container_create_with_host_volumes standalone -d \
+    -e MARIADB_USER=$MARIADB_USER \
+    -e MARIADB_DATABASE=$MARIADB_DATABASE \
+    -e MARIADB_PASSWORD=$MARIADB_PASSWORD
+
+  # restart container multiple times
+  container_restart standalone
+  container_restart standalone
+
+  # auth as MARIADB_USER and check of MARIADB_DATABASE exists
+  run mysql_client standalone -u$MARIADB_USER -p$MARIADB_PASSWORD -e "SHOW DATABASES\G"
+  [[ "$output" =~ "Database: $MARIADB_DATABASE" ]]
+}
+
 @test "If host mounted, password and settings are preserved after deletion" {
   container_create_with_host_volumes standalone -d \
     -e MARIADB_USER=$MARIADB_USER \


### PR DESCRIPTION
The existence of the `/tmp/init_mysql.sql` from a previous run of the
container breaks the container on subsequent launches.

Fixes #6