### PR TITLE
Fix incorrect custom settings file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The above command scales up the number of slaves to `3`. You can scale down in t
 
 ## Configuration file
 
-The image looks for configuration in the `conf/` directory of `/bitnami/mariadb`. As as mentioned in [Persisting your database](#persisting-your-data) you can mount a volume at this location and copy your own configuration file in the `conf/` directory as my-custom.cnf. That file will be included in the main configuration file and will overwrite any configuration you want to modify.
+The image looks for configuration in the `conf/` directory of `/bitnami/mariadb`. As as mentioned in [Persisting your database](#persisting-your-data) you can mount a volume at this location and copy your own configuration file in the `conf/` directory as my_custom.cnf. That file will be included in the main configuration file and will overwrite any configuration you want to modify.
 
 ### Step 1: Run the MariaDB image
 


### PR DESCRIPTION
I think the correct file name is `my_custom.cnf` instead of `my-custom.cnf`.

```
root@9b78f333f64d:/# cat /bitnami/mariadb/conf/my.cnf 
[mysqladmin]
user=

[mysqld]
skip-name-resolve
basedir=/opt/bitnami/mariadb
port=3306
socket=/opt/bitnami/mariadb/tmp/mysql.sock
tmpdir=/opt/bitnami/mariadb/tmp
max_allowed_packet=16M
bind-address=0.0.0.0
pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
log-error=/opt/bitnami/mariadb/logs/mysqld.log
character-set-server=UTF8
collation-server=utf8_general_ci

[client]
port=3306
socket=/opt/bitnami/mariadb/tmp/mysql.sock
default-character-set=UTF8

[manager]
port=3306
socket=/opt/bitnami/mariadb/tmp/mysql.sock
pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid

!include /bitnami/mariadb/conf/my_custom.cnf
```