### PR TITLE
fixes the indirect reference in check_for_deprecated_env

### DIFF
--- a/10/rootfs/app-entrypoint.sh
+++ b/10/rootfs/app-entrypoint.sh
@@ -27,7 +27,7 @@ empty_password_enabled_warn() {
 ## param $2   Suggested environment variable to use
 ##
 check_for_deprecated_env() {
-  if [[ -n "$$1" ]]; then
+  if [[ -n "${!1}" ]]; then
     warn "The environment variable $1 is deprecated and will be removed in a future. Please use $2 instead"
   fi
 }


### PR DESCRIPTION
**Description of the change**

Use indirect reference in the check_for_deprecated_env function. This fixes a bad usage of indirect references.

This prevents the `app-entrypoint.sh` from prompting the user when the deprecated env vars are not set.
