### PR TITLE
Avoid using MARIADB_ROOT_XXX env. variable on slaves

### DIFF
--- a/10.1/debian-9/rootfs/libmysql.sh
+++ b/10.1/debian-9/rootfs/libmysql.sh
@@ -271,9 +271,15 @@ EOF
             mysql_upgrade
         else
             info "Flushing privileges..."
-            mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
+            if  [ "$DB_REPLICATION_MODE" == "master" ]; then
+                mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
 flush privileges;
 EOF
+            else
+                mysql_execute "mysql" <<EOF
+flush privileges;
+EOF
+            fi
         fi
     fi
 }

--- a/10.1/ol-7/rootfs/libmysql.sh
+++ b/10.1/ol-7/rootfs/libmysql.sh
@@ -271,9 +271,15 @@ EOF
             mysql_upgrade
         else
             info "Flushing privileges..."
-            mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
+            if  [ "$DB_REPLICATION_MODE" == "master" ]; then
+                mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
 flush privileges;
 EOF
+            else
+                mysql_execute "mysql" <<EOF
+flush privileges;
+EOF
+            fi
         fi
     fi
 }

--- a/10.1/rhel-7/rootfs/libmysql.sh
+++ b/10.1/rhel-7/rootfs/libmysql.sh
@@ -271,9 +271,15 @@ EOF
             mysql_upgrade
         else
             info "Flushing privileges..."
-            mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
+            if  [ "$DB_REPLICATION_MODE" == "master" ]; then
+                mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
 flush privileges;
 EOF
+            else
+                mysql_execute "mysql" <<EOF
+flush privileges;
+EOF
+            fi
         fi
     fi
 }

--- a/10.2/debian-9/rootfs/libmysql.sh
+++ b/10.2/debian-9/rootfs/libmysql.sh
@@ -271,9 +271,15 @@ EOF
             mysql_upgrade
         else
             info "Flushing privileges..."
-            mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
+            if  [ "$DB_REPLICATION_MODE" == "master" ]; then
+                mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
 flush privileges;
 EOF
+            else
+                mysql_execute "mysql" <<EOF
+flush privileges;
+EOF
+            fi
         fi
     fi
 }

--- a/10.2/ol-7/rootfs/libmysql.sh
+++ b/10.2/ol-7/rootfs/libmysql.sh
@@ -271,9 +271,15 @@ EOF
             mysql_upgrade
         else
             info "Flushing privileges..."
-            mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
+            if  [ "$DB_REPLICATION_MODE" == "master" ]; then
+                mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
 flush privileges;
 EOF
+            else
+                mysql_execute "mysql" <<EOF
+flush privileges;
+EOF
+            fi
         fi
     fi
 }

--- a/10.2/rhel-7/rootfs/libmysql.sh
+++ b/10.2/rhel-7/rootfs/libmysql.sh
@@ -271,9 +271,15 @@ EOF
             mysql_upgrade
         else
             info "Flushing privileges..."
-            mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
+            if  [ "$DB_REPLICATION_MODE" == "master" ]; then
+                mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
 flush privileges;
 EOF
+            else
+                mysql_execute "mysql" <<EOF
+flush privileges;
+EOF
+            fi
         fi
     fi
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Slaves should only use **MARIADB_MASTER_ROOT_XXX** env. variables instead of **MARIADB_MASTER_ROOT_XXX**. 

We can find misconfigurations when setting both env vars.
