### PR TITLE
Avoid false error 1045 for password too long in nodes slave

### DIFF
--- a/10.1/debian-9/rootfs/libmysql.sh
+++ b/10.1/debian-9/rootfs/libmysql.sh
@@ -65,6 +65,10 @@ mysql_valid_settings() {
         error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
         exit 1
     }
+    long_password_error() {
+        error "The password can not be longer than 32 characters. Set the environment variable $1 with a shorter value"
+        exit 1
+    }
 
     if [ ! -z "$DB_REPLICATION_MODE" ]; then
         if [ "$DB_REPLICATION_MODE" == "master" ]; then
@@ -78,8 +82,7 @@ mysql_valid_settings() {
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if (( ${#DB_ROOT_PASSWORD} > 32 )); then
-                    error "The password can not be longer than 32 characters"
-                    exit 1
+                    long_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"

--- a/10.1/debian-9/rootfs/libmysql.sh
+++ b/10.1/debian-9/rootfs/libmysql.sh
@@ -77,6 +77,10 @@ mysql_valid_settings() {
                 if [ -z "$DB_ROOT_PASSWORD" ]; then
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
+                if (( ${#DB_ROOT_PASSWORD} > 32 )); then
+                    error "The password can not be longer than 32 characters"
+                    exit 1
+                fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"
                 fi

--- a/10.1/ol-7/rootfs/libmysql.sh
+++ b/10.1/ol-7/rootfs/libmysql.sh
@@ -65,6 +65,10 @@ mysql_valid_settings() {
         error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
         exit 1
     }
+    long_password_error() {
+        error "The password can not be longer than 32 characters. Set the environment variable $1 with a shorter value"
+        exit 1
+    }
 
     if [ ! -z "$DB_REPLICATION_MODE" ]; then
         if [ "$DB_REPLICATION_MODE" == "master" ]; then
@@ -78,8 +82,7 @@ mysql_valid_settings() {
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if (( ${#DB_ROOT_PASSWORD} > 32 )); then
-                    error "The password can not be longer than 32 characters"
-                    exit 1
+                    long_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"

--- a/10.1/ol-7/rootfs/libmysql.sh
+++ b/10.1/ol-7/rootfs/libmysql.sh
@@ -77,6 +77,10 @@ mysql_valid_settings() {
                 if [ -z "$DB_ROOT_PASSWORD" ]; then
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
+                if (( ${#DB_ROOT_PASSWORD} > 32 )); then
+                    error "The password can not be longer than 32 characters"
+                    exit 1
+                fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"
                 fi

--- a/10.1/rhel-7/rootfs/libmysql.sh
+++ b/10.1/rhel-7/rootfs/libmysql.sh
@@ -65,6 +65,10 @@ mysql_valid_settings() {
         error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
         exit 1
     }
+    long_password_error() {
+        error "The password can not be longer than 32 characters. Set the environment variable $1 with a shorter value"
+        exit 1
+    }
 
     if [ ! -z "$DB_REPLICATION_MODE" ]; then
         if [ "$DB_REPLICATION_MODE" == "master" ]; then
@@ -78,8 +82,7 @@ mysql_valid_settings() {
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if (( ${#DB_ROOT_PASSWORD} > 32 )); then
-                    error "The password can not be longer than 32 characters"
-                    exit 1
+                    long_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"

--- a/10.1/rhel-7/rootfs/libmysql.sh
+++ b/10.1/rhel-7/rootfs/libmysql.sh
@@ -77,6 +77,10 @@ mysql_valid_settings() {
                 if [ -z "$DB_ROOT_PASSWORD" ]; then
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
+                if (( ${#DB_ROOT_PASSWORD} > 32 )); then
+                    error "The password can not be longer than 32 characters"
+                    exit 1
+                fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"
                 fi

--- a/10.2/debian-9/rootfs/libmysql.sh
+++ b/10.2/debian-9/rootfs/libmysql.sh
@@ -65,6 +65,10 @@ mysql_valid_settings() {
         error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
         exit 1
     }
+    long_password_error() {
+        error "The password can not be longer than 32 characters. Set the environment variable $1 with a shorter value"
+        exit 1
+    }
 
     if [ ! -z "$DB_REPLICATION_MODE" ]; then
         if [ "$DB_REPLICATION_MODE" == "master" ]; then
@@ -78,8 +82,7 @@ mysql_valid_settings() {
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if (( ${#DB_ROOT_PASSWORD} > 32 )); then
-                    error "The password can not be longer than 32 characters"
-                    exit 1
+                    long_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"

--- a/10.2/debian-9/rootfs/libmysql.sh
+++ b/10.2/debian-9/rootfs/libmysql.sh
@@ -77,6 +77,10 @@ mysql_valid_settings() {
                 if [ -z "$DB_ROOT_PASSWORD" ]; then
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
+                if (( ${#DB_ROOT_PASSWORD} > 32 )); then
+                    error "The password can not be longer than 32 characters"
+                    exit 1
+                fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"
                 fi

--- a/10.2/ol-7/rootfs/libmysql.sh
+++ b/10.2/ol-7/rootfs/libmysql.sh
@@ -65,6 +65,10 @@ mysql_valid_settings() {
         error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
         exit 1
     }
+    long_password_error() {
+        error "The password can not be longer than 32 characters. Set the environment variable $1 with a shorter value"
+        exit 1
+    }
 
     if [ ! -z "$DB_REPLICATION_MODE" ]; then
         if [ "$DB_REPLICATION_MODE" == "master" ]; then
@@ -78,8 +82,7 @@ mysql_valid_settings() {
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if (( ${#DB_ROOT_PASSWORD} > 32 )); then
-                    error "The password can not be longer than 32 characters"
-                    exit 1
+                    long_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"

--- a/10.2/ol-7/rootfs/libmysql.sh
+++ b/10.2/ol-7/rootfs/libmysql.sh
@@ -77,6 +77,10 @@ mysql_valid_settings() {
                 if [ -z "$DB_ROOT_PASSWORD" ]; then
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
+                if (( ${#DB_ROOT_PASSWORD} > 32 )); then
+                    error "The password can not be longer than 32 characters"
+                    exit 1
+                fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"
                 fi

--- a/10.2/rhel-7/rootfs/libmysql.sh
+++ b/10.2/rhel-7/rootfs/libmysql.sh
@@ -65,6 +65,10 @@ mysql_valid_settings() {
         error "The $1 environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
         exit 1
     }
+    long_password_error() {
+        error "The password can not be longer than 32 characters. Set the environment variable $1 with a shorter value"
+        exit 1
+    }
 
     if [ ! -z "$DB_REPLICATION_MODE" ]; then
         if [ "$DB_REPLICATION_MODE" == "master" ]; then
@@ -78,8 +82,7 @@ mysql_valid_settings() {
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if (( ${#DB_ROOT_PASSWORD} > 32 )); then
-                    error "The password can not be longer than 32 characters"
-                    exit 1
+                    long_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"

--- a/10.2/rhel-7/rootfs/libmysql.sh
+++ b/10.2/rhel-7/rootfs/libmysql.sh
@@ -77,6 +77,10 @@ mysql_valid_settings() {
                 if [ -z "$DB_ROOT_PASSWORD" ]; then
                     empty_password_error "$(get_env_var ROOT_PASSWORD)"
                 fi
+                if (( ${#DB_ROOT_PASSWORD} > 32 )); then
+                    error "The password can not be longer than 32 characters"
+                    exit 1
+                fi
                 if [ -n "$DB_USER" ] && [ -z "$DB_PASSWORD" ]; then
                     empty_password_error "$(get_env_var PASSWORD)"
                 fi


### PR DESCRIPTION
**Description of the change**

Checks the internal variable DB_ROOT_PASSWORD so that the length is less than 32 characters.

**Log on the slave node with a password longer than 32 characters**

In principle the error only affect in MARIADB_ROOT_PASSWORD, but it would I not rule out the rest.
```
[ERROR] Slave I/O: error connecting to master 'replication_user@mariadb-master:3306' - retry-time: 10  maximum-retries: 86400  message: Access denied for user 'replication_user'@'10.32.0.62' (using password: YES), Internal MariaDB error code: 1045
```

**Benefits**

Avoid false error 1045 for password too long in nodes slave.

**Additional information**

https://chrisshort.net/an-annoying-mysql-replication-error-code-1045/
