### PR TITLE
Create User for UID 1001

### DIFF
--- a/10.1/debian-9/Dockerfile
+++ b/10.1/debian-9/Dockerfile
@@ -7,6 +7,9 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
     OS_FLAVOUR="debian-9" \
     OS_NAME="linux"
 
+# Create mariadb user, which will be the default user
+RUN adduser --home / --no-create-home --uid 1001 --gecos "mariadb" --disabled-password --gid 0 mariadb
+
 # Install required system packages and dependencies
 RUN install_packages libaio1 libc6 libgcc1 libjemalloc1 libncurses5 libssl1.0.2 libstdc++6 libtinfo5 zlib1g
 RUN . ./libcomponent.sh && component_unpack "mariadb" "10.1.38-0" --checksum c1f6b5f4206fd191acd3f538b3ecb00d94bce3c96a28349f5369bdea96f5cd93

--- a/10.1/ol-7/Dockerfile
+++ b/10.1/ol-7/Dockerfile
@@ -7,6 +7,9 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
     OS_FLAVOUR="ol-7" \
     OS_NAME="linux"
 
+# Create mariadb user, which will be the default user
+RUN adduser --comment "mariadb" --home-dir / --gid 0 --no-create-home --no-user-group --password '*' --uid 1001 mariadb
+
 # Install required system packages and dependencies
 RUN install_packages glibc keyutils-libs krb5-libs libaio libcom_err libgcc libselinux libstdc++ ncurses-libs nss-softokn-freebl openssl-libs pcre zlib
 RUN . ./libcomponent.sh && component_unpack "mariadb" "10.1.38-0" --checksum f5847c173605cfc41929b25ee7830d1f59a2b98ccf7142758c9e51d6bd9677bb

--- a/10.1/rhel-7/Dockerfile
+++ b/10.1/rhel-7/Dockerfile
@@ -7,6 +7,9 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
     OS_FLAVOUR="rhel-7" \
     OS_NAME="linux"
 
+# Create mariadb user, which will be the default user
+RUN useradd --comment "mariadb" --home-dir / --gid 0 --no-create-home --no-user-group --password '*' --uid 1001 mariadb
+
 # Install required system packages and dependencies
 RUN install_packages glibc keyutils-libs krb5-libs libaio libcom_err libgcc libselinux libstdc++ ncurses-libs nss-softokn-freebl openssl-libs pcre zlib
 RUN . ./libcomponent.sh && component_unpack "mariadb" "10.1.38-0" --checksum f8a5afd74219834adcc3faaf60baa46901b64de16f2cefeb680b27fda449b952

--- a/10.2/debian-9/Dockerfile
+++ b/10.2/debian-9/Dockerfile
@@ -7,6 +7,9 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
     OS_FLAVOUR="debian-9" \
     OS_NAME="linux"
 
+# Create mariadb user, which will be the default user
+RUN adduser --home / --no-create-home --uid 1001 --gecos "mariadb" --disabled-password --gid 0 mariadb
+
 # Install required system packages and dependencies
 RUN install_packages libaio1 libc6 libgcc1 libjemalloc1 libncurses5 libssl1.0.2 libstdc++6 libtinfo5 zlib1g
 RUN . ./libcomponent.sh && component_unpack "mariadb" "10.2.23-0" --checksum 967d847ab5dc513ef3b56337978866e7d876a4cb820e076ca3f4a81a8270289d

--- a/10.2/ol-7/Dockerfile
+++ b/10.2/ol-7/Dockerfile
@@ -7,6 +7,9 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
     OS_FLAVOUR="ol-7" \
     OS_NAME="linux"
 
+# Create mariadb user, which will be the default user
+RUN adduser --comment "mariadb" --home-dir / --gid 0 --no-create-home --no-user-group --password '*' --uid 1001 mariadb
+
 # Install required system packages and dependencies
 RUN install_packages glibc keyutils-libs krb5-libs libaio libcom_err libgcc libselinux libstdc++ ncurses-libs nss-softokn-freebl openssl-libs pcre zlib
 RUN . ./libcomponent.sh && component_unpack "mariadb" "10.2.23-0" --checksum 4d45aa74ad97e9f6c858a6836df290605120743e2b8067526d930cfd3cdc6af7

--- a/10.2/rhel-7/Dockerfile
+++ b/10.2/rhel-7/Dockerfile
@@ -7,6 +7,9 @@ ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
     OS_FLAVOUR="rhel-7" \
     OS_NAME="linux"
 
+# Create mariadb user, which will be the default user
+RUN useradd --comment "mariadb" --home-dir / --gid 0 --no-create-home --no-user-group --password '*' --uid 1001 mariadb
+
 # Install required system packages and dependencies
 RUN install_packages glibc keyutils-libs krb5-libs libaio libcom_err libgcc libselinux libstdc++ ncurses-libs nss-softokn-freebl openssl-libs pcre zlib
 RUN . ./libcomponent.sh && component_unpack "mariadb" "10.2.23-0" --checksum d1cb2c039a810e764559455bbf165ffe91fbfcc75b062be567262285214b1510


### PR DESCRIPTION
**Description of the change**

This commit creates a user to match UID 1001, which is the default user
for these containers. 

**Benefits**

This will fix some of the quirky behavior that
occurs when running as a UID with no backing user.

**Possible drawbacks**

This change attempts to keep the behavior as close to what was happening
previously, in order to prevent breaking anyone's build who relies on
the existing behavior. This _should_ be a non-breaking change, but no
guarantees.

**Applicable issues**

Not sure if any apply at this time.