### PR TITLE
Don't override user specified extra flags

### DIFF
--- a/10.1/debian-9/rootfs/libmysql.sh
+++ b/10.1/debian-9/rootfs/libmysql.sh
@@ -217,8 +217,9 @@ mysql_stop() {
 mysql_extra_flags() {
     local randNumber
     local dbExtraFlags
+    local userExtraFlags
     randNumber=$(head /dev/urandom | tr -dc 0-9 | head -c 3 ; echo '')
-    read -r -a dbExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
+    read -r -a userExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
 
     if [[ -n "$DB_REPLICATION_MODE" ]]; then
         dbExtraFlags+=("--server-id=$randNumber" "--binlog-format=ROW" "--log-bin=mysql-bin" "--sync-binlog=1")
@@ -231,6 +232,8 @@ mysql_extra_flags() {
             dbExtraFlags+=("--innodb_flush_log_at_trx_commit=1")
         fi
     fi
+
+    dbExtraFlags+=("${userExtraFlags[@]}")
 
     echo "${dbExtraFlags[@]}"
 }

--- a/10.1/ol-7/rootfs/libmysql.sh
+++ b/10.1/ol-7/rootfs/libmysql.sh
@@ -217,8 +217,9 @@ mysql_stop() {
 mysql_extra_flags() {
     local randNumber
     local dbExtraFlags
+    local userExtraFlags
     randNumber=$(head /dev/urandom | tr -dc 0-9 | head -c 3 ; echo '')
-    read -r -a dbExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
+    read -r -a userExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
 
     if [[ -n "$DB_REPLICATION_MODE" ]]; then
         dbExtraFlags+=("--server-id=$randNumber" "--binlog-format=ROW" "--log-bin=mysql-bin" "--sync-binlog=1")
@@ -231,6 +232,8 @@ mysql_extra_flags() {
             dbExtraFlags+=("--innodb_flush_log_at_trx_commit=1")
         fi
     fi
+
+    dbExtraFlags+=("${userExtraFlags[@]}")
 
     echo "${dbExtraFlags[@]}"
 }

--- a/10.2/debian-9/rootfs/libmysql.sh
+++ b/10.2/debian-9/rootfs/libmysql.sh
@@ -217,8 +217,9 @@ mysql_stop() {
 mysql_extra_flags() {
     local randNumber
     local dbExtraFlags
+    local userExtraFlags
     randNumber=$(head /dev/urandom | tr -dc 0-9 | head -c 3 ; echo '')
-    read -r -a dbExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
+    read -r -a userExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
 
     if [[ -n "$DB_REPLICATION_MODE" ]]; then
         dbExtraFlags+=("--server-id=$randNumber" "--binlog-format=ROW" "--log-bin=mysql-bin" "--sync-binlog=1")
@@ -231,6 +232,8 @@ mysql_extra_flags() {
             dbExtraFlags+=("--innodb_flush_log_at_trx_commit=1")
         fi
     fi
+
+    dbExtraFlags+=("${userExtraFlags[@]}")
 
     echo "${dbExtraFlags[@]}"
 }

--- a/10.2/ol-7/rootfs/libmysql.sh
+++ b/10.2/ol-7/rootfs/libmysql.sh
@@ -217,8 +217,9 @@ mysql_stop() {
 mysql_extra_flags() {
     local randNumber
     local dbExtraFlags
+    local userExtraFlags
     randNumber=$(head /dev/urandom | tr -dc 0-9 | head -c 3 ; echo '')
-    read -r -a dbExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
+    read -r -a userExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
 
     if [[ -n "$DB_REPLICATION_MODE" ]]; then
         dbExtraFlags+=("--server-id=$randNumber" "--binlog-format=ROW" "--log-bin=mysql-bin" "--sync-binlog=1")
@@ -231,6 +232,8 @@ mysql_extra_flags() {
             dbExtraFlags+=("--innodb_flush_log_at_trx_commit=1")
         fi
     fi
+
+    dbExtraFlags+=("${userExtraFlags[@]}")
 
     echo "${dbExtraFlags[@]}"
 }

--- a/10.3/debian-9/rootfs/libmysql.sh
+++ b/10.3/debian-9/rootfs/libmysql.sh
@@ -217,8 +217,9 @@ mysql_stop() {
 mysql_extra_flags() {
     local randNumber
     local dbExtraFlags
+    local userExtraFlags
     randNumber=$(head /dev/urandom | tr -dc 0-9 | head -c 3 ; echo '')
-    read -r -a dbExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
+    read -r -a userExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
 
     if [[ -n "$DB_REPLICATION_MODE" ]]; then
         dbExtraFlags+=("--server-id=$randNumber" "--binlog-format=ROW" "--log-bin=mysql-bin" "--sync-binlog=1")
@@ -231,6 +232,8 @@ mysql_extra_flags() {
             dbExtraFlags+=("--innodb_flush_log_at_trx_commit=1")
         fi
     fi
+
+    dbExtraFlags+=("${userExtraFlags[@]}")
 
     echo "${dbExtraFlags[@]}"
 }

--- a/10.3/ol-7/rootfs/libmysql.sh
+++ b/10.3/ol-7/rootfs/libmysql.sh
@@ -217,8 +217,9 @@ mysql_stop() {
 mysql_extra_flags() {
     local randNumber
     local dbExtraFlags
+    local userExtraFlags
     randNumber=$(head /dev/urandom | tr -dc 0-9 | head -c 3 ; echo '')
-    read -r -a dbExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
+    read -r -a userExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
 
     if [[ -n "$DB_REPLICATION_MODE" ]]; then
         dbExtraFlags+=("--server-id=$randNumber" "--binlog-format=ROW" "--log-bin=mysql-bin" "--sync-binlog=1")
@@ -231,6 +232,8 @@ mysql_extra_flags() {
             dbExtraFlags+=("--innodb_flush_log_at_trx_commit=1")
         fi
     fi
+
+    dbExtraFlags+=("${userExtraFlags[@]}")
 
     echo "${dbExtraFlags[@]}"
 }


### PR DESCRIPTION
**Description of the change**

This PR changes the way user specified extra flags are processed, appending them after our flags so that they take precedence over the defaults.

**Benefits**

User specified flags are not overriden by defaults.

**Applicable issues**

#194 
