### PR TITLE
Add ---skip-test-db capabilities

### DIFF
--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -707,6 +707,9 @@ mysql_install_db() {
     am_i_root && args=("${args[@]}" "--user=$DB_DAEMON_USER")
     if [[ "$DB_FLAVOR" = "mariadb" ]]; then
         args+=("--auth-root-authentication-method=normal")
+        if [[ ! "$(mysql_get_version)" =~ ^10.[01234]. ]]; then
+            is_boolean_yes "$MARIADB_SKIP_TEST_DB" && args+=("--skip-test-db")
+        fi
     else
         command="${DB_BIN_DIR}/mysqld"
         args+=("--initialize-insecure")

--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -47,6 +47,7 @@ mariadb_env_vars=(
     MARIADB_CLIENT_SSL_CERT_FILE
     MARIADB_CLIENT_SSL_KEY_FILE
     MARIADB_CLIENT_EXTRA_FLAGS
+    MARIADB_SKIP_TEST_DB
 )
 for env_var in "${mariadb_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -148,3 +149,4 @@ export MARIADB_CLIENT_EXTRA_FLAGS="${MARIADB_CLIENT_EXTRA_FLAGS:-no}"
 export DB_CLIENT_EXTRA_FLAGS="$MARIADB_CLIENT_EXTRA_FLAGS"
 
 # Custom environment variables may be defined below
+export MARIADB_SKIP_TEST_DB="${MARIADB_SKIP_TEST_DB:-no}"

--- a/10.3/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.3/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -707,6 +707,9 @@ mysql_install_db() {
     am_i_root && args=("${args[@]}" "--user=$DB_DAEMON_USER")
     if [[ "$DB_FLAVOR" = "mariadb" ]]; then
         args+=("--auth-root-authentication-method=normal")
+        if [[ ! "$(mysql_get_version)" =~ ^10.[01234]. ]]; then
+            is_boolean_yes "$MARIADB_SKIP_TEST_DB" && args+=("--skip-test-db")
+        fi
     else
         command="${DB_BIN_DIR}/mysqld"
         args+=("--initialize-insecure")

--- a/10.3/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.3/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -47,6 +47,7 @@ mariadb_env_vars=(
     MARIADB_CLIENT_SSL_CERT_FILE
     MARIADB_CLIENT_SSL_KEY_FILE
     MARIADB_CLIENT_EXTRA_FLAGS
+    MARIADB_SKIP_TEST_DB
 )
 for env_var in "${mariadb_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -148,3 +149,4 @@ export MARIADB_CLIENT_EXTRA_FLAGS="${MARIADB_CLIENT_EXTRA_FLAGS:-no}"
 export DB_CLIENT_EXTRA_FLAGS="$MARIADB_CLIENT_EXTRA_FLAGS"
 
 # Custom environment variables may be defined below
+export MARIADB_SKIP_TEST_DB="${MARIADB_SKIP_TEST_DB:-no}"

--- a/10.4/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.4/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -707,6 +707,9 @@ mysql_install_db() {
     am_i_root && args=("${args[@]}" "--user=$DB_DAEMON_USER")
     if [[ "$DB_FLAVOR" = "mariadb" ]]; then
         args+=("--auth-root-authentication-method=normal")
+        if [[ ! "$(mysql_get_version)" =~ ^10.[01234]. ]]; then
+            is_boolean_yes "$MARIADB_SKIP_TEST_DB" && args+=("--skip-test-db")
+        fi
     else
         command="${DB_BIN_DIR}/mysqld"
         args+=("--initialize-insecure")

--- a/10.4/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.4/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -47,6 +47,7 @@ mariadb_env_vars=(
     MARIADB_CLIENT_SSL_CERT_FILE
     MARIADB_CLIENT_SSL_KEY_FILE
     MARIADB_CLIENT_EXTRA_FLAGS
+    MARIADB_SKIP_TEST_DB
 )
 for env_var in "${mariadb_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -148,3 +149,4 @@ export MARIADB_CLIENT_EXTRA_FLAGS="${MARIADB_CLIENT_EXTRA_FLAGS:-no}"
 export DB_CLIENT_EXTRA_FLAGS="$MARIADB_CLIENT_EXTRA_FLAGS"
 
 # Custom environment variables may be defined below
+export MARIADB_SKIP_TEST_DB="${MARIADB_SKIP_TEST_DB:-no}"

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -711,6 +711,9 @@ mysql_install_db() {
         command="${DB_BIN_DIR}/mysqld"
         args+=("--initialize-insecure")
     fi
+    if [[ -v SKIP_TEST_DB ]] && [[ "$SKIP_TEST_DB" == "true" ]]; then
+        args+=("--skip-test-db")
+    fi
     debug_execute "$command" "${args[@]}"
 }
 

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -707,12 +707,12 @@ mysql_install_db() {
     am_i_root && args=("${args[@]}" "--user=$DB_DAEMON_USER")
     if [[ "$DB_FLAVOR" = "mariadb" ]]; then
         args+=("--auth-root-authentication-method=normal")
+        if [[ ! "$(mysql_get_version)" =~ ^10.[01234]. ]]; then
+            is_boolean_yes "$MARIADB_SKIP_TEST_DB" && args+=("--skip-test-db")
+        fi
     else
         command="${DB_BIN_DIR}/mysqld"
         args+=("--initialize-insecure")
-    fi
-    if [[ -v SKIP_TEST_DB ]] && [[ "$SKIP_TEST_DB" == "true" ]]; then
-        args+=("--skip-test-db")
     fi
     debug_execute "$command" "${args[@]}"
 }

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -47,6 +47,7 @@ mariadb_env_vars=(
     MARIADB_CLIENT_SSL_CERT_FILE
     MARIADB_CLIENT_SSL_KEY_FILE
     MARIADB_CLIENT_EXTRA_FLAGS
+    MARIADB_SKIP_TEST_DB
 )
 for env_var in "${mariadb_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -75,7 +76,6 @@ export DB_CONF_FILE="${DB_CONF_DIR}/my.cnf"
 export DB_PID_FILE="${DB_TMP_DIR}/mysqld.pid"
 export DB_SOCKET_FILE="${DB_TMP_DIR}/mysql.sock"
 export PATH="${DB_SBIN_DIR}:${DB_BIN_DIR}:/opt/bitnami/common/bin:${PATH}"
-
 # System users (when running with a privileged user)
 export DB_DAEMON_USER="mysql"
 export DB_DAEMON_GROUP="mysql"
@@ -148,3 +148,4 @@ export MARIADB_CLIENT_EXTRA_FLAGS="${MARIADB_CLIENT_EXTRA_FLAGS:-no}"
 export DB_CLIENT_EXTRA_FLAGS="$MARIADB_CLIENT_EXTRA_FLAGS"
 
 # Custom environment variables may be defined below
+export MARIADB_SKIP_TEST_DB="${MARIADB_SKIP_TEST_DB:-no}"

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ services:
   ...
 ```
 
-## Disable test databse
+## Disable creation of test database
 
 By default the MariaDB process create test database, in order to disable creation of test database "--skip-test-db" could be added on mysql_install_db process.
 This function is available on version equal or higher than 10.5 of mariadb.

--- a/README.md
+++ b/README.md
@@ -259,6 +259,21 @@ services:
   ...
 ```
 
+## Disable test databse
+
+By default the MariaDB process create test database, in order to disable creation of test database "--skip-test-db" could be added on mysql_install_db process.
+This function is available on version equal or higher than 10.5 of mariadb.
+
+by passing the `SKIP_TEST_DB` environment variable when running the image for the first time, the test database won't be create
+
+```console
+$ docker run --name mariadb \
+    -e ALLOW_EMPTY_PASSWORD=yes \
+    -e SKIP_TEST_DB=true \
+    bitnami/mariadb:latest
+```
+
+
 ## Creating a database on first run
 
 By passing the `MARIADB_DATABASE` environment variable when running the image for the first time, a database will be created. This is useful if your application requires that a database already exists, saving you from having to manually create the database using the MySQL client.


### PR DESCRIPTION
Description of the change

Add the capability to disable  creation of test database 

Benefits

Users will be able to pass environment variable to disable the creation of test database instead of add post bootstrap scripts

Additional information

Feature available only in version 10.5+