### PR TITLE
Use default character set 'utf8mb4' and collation set utf8mb4_general_ci

### DIFF
--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -86,9 +86,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_general_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/10.3/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.3/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -86,9 +86,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_general_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/10.4/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.4/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -86,9 +86,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_general_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -86,9 +86,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_general_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/10.6/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.6/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -86,9 +86,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_general_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time


### PR DESCRIPTION
Use default character set `utf8mb4` and collation set `utf8mb4_general_ci` instead of `utf8` and `utf8_general_ci`.

https://mariadb.com/kb/en/supported-character-sets-and-collations/
https://mariadb.com/kb/en/unicode/

> Until MariaDB 10.5, this was a UTF-8 encoding using one to three bytes per character. Basic Latin letters, numbers and punctuation use one byte. European and Middle East letters mostly fit into 2 bytes. Korean, Chinese, and Japanese ideographs use 3-bytes. No supplementary characters are stored. From MariaDB 10.6, utf8 is an alias for utf8mb3, but this can changed to ut8mb4 by changing the default value of the old_mode system variable.

Related issues/PRs: #217, #254