### PR TITLE
Allow any password for container users (+ misc other fixes)

### DIFF
--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -508,8 +508,8 @@ mysql_execute_print_output() {
     # Obtain the command specified via stdin
     local mysql_cmd
     mysql_cmd="$(</dev/stdin)"
-    MYSQL_PWD="${pass}" debug "Executing SQL command:\n$mysql_cmd"
-    "$DB_BIN_DIR/mysql" "${args[@]}" <<<"$mysql_cmd"
+    debug "Executing SQL command:\n$mysql_cmd"
+    MYSQL_PWD="${pass}" "$DB_BIN_DIR/mysql" "${args[@]}" <<<"$mysql_cmd"
 }
 
 ########################

--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -180,7 +180,11 @@ mysql_configure_replication() {
         debug "Replication master ready!"
         debug "Setting the master configuration"
         local -r db_repl_password=$(mysql_sql_escape_string_literal "$DB_REPLICATION_PASSWORD")
-        mysql_execute "mysql" --binary-mode <<EOF
+	# The flush privileges in the slave mode is necessary. The other flush is done for master
+	# and non-replication configurations in mysql_ensure_root_user_exists
+        mysql_execute "mysql" "root" "" --binary-mode <<EOF
+-- Flush the previous clearing of privs with DELETE
+FLUSH PRIVILEGES;
 -- we need the SQL_MODE NO_BACKSLASH_ESCAPES mode to be clear for the password to be set
 SET @@SESSION.SQL_MODE=REPLACE(@@SESSION.SQL_MODE, 'NO_BACKSLASH_ESCAPES', '');
 CHANGE MASTER TO MASTER_HOST='$DB_MASTER_HOST',
@@ -312,7 +316,8 @@ EOF
             [[ -n "$DB_ROOT_PASSWORD" ]] && export ROOT_AUTH_ENABLED="yes"
         fi
         [[ -n "$DB_REPLICATION_MODE" ]] && mysql_configure_replication
-        # we run mysql_upgrade in order to recreate necessary database users and flush privileges
+        # we run mysql_upgrade in order to update system tables to support newer features and mariadb.sys
+	# ownership of mysql.users view.
         mysql_upgrade
     fi
 }
@@ -741,8 +746,8 @@ mysql_upgrade() {
         mysql_stop
         mysql_start_bg "--upgrade=FORCE"
     else
-        mysql_start_bg --skip-grant-tables
-        debug_execute "${DB_BIN_DIR}/mysql_upgrade" "${args[@]}"
+        mysql_start_bg
+        MYSQL_PWD="$DB_ROOT_PASSWORD" debug_execute "${DB_BIN_DIR}/mysql_upgrade" "${args[@]}"
     fi
 }
 
@@ -937,19 +942,19 @@ mysql_ensure_root_user_exists() {
     if [[ "$DB_FLAVOR" = "mariadb" ]]; then
         # shellcheck disable=SC2016
         mysql_execute "mysql" "root" "" "--binary-mode" <<EOF
--- create root@localhost user for local admin access
--- create user 'root'@'localhost' ${epassword:+identified by '${epassword}'};
--- grant all on *.* to 'root'@'localhost' with grant option;
--- create admin user for remote access
+-- last use of password root user previously removed.
+FLUSH PRIVILEGES;
 -- we need the SQL_MODE NO_BACKSLASH_ESCAPES mode to be clear for the password to be set
 SET @@SESSION.SQL_MODE=REPLACE(@@SESSION.SQL_MODE, 'NO_BACKSLASH_ESCAPES', '');
+-- create admin user for remote access
 create user '$user'@'%' ${password:+identified ${auth_plugin_str} by '${epassword}'};
 grant all on *.* to '$user'@'%' with grant option;
 EOF
     else
         # shellcheck disable=SC2016
-        mysql_execute "mysql" "root" --binary-mode <<EOF
+        mysql_execute "mysql" "root" "" --binary-mode <<EOF
 -- create admin user
+FLUSH PRIVILEGES;
 SET @@SESSION.SQL_MODE=REPLACE(@@SESSION.SQL_MODE, 'NO_BACKSLASH_ESCAPES', '');
 create user '$user'@'%' ${epassword:+identified by '${epassword}'};
 grant all on *.* to '$user'@'%' with grant option;

--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -936,7 +936,7 @@ mysql_ensure_root_user_exists() {
     debug "Configuring root user credentials"
     if [[ "$DB_FLAVOR" = "mariadb" ]]; then
         # shellcheck disable=SC2016
-        mysql_execute "mysql" "root" --binary-mode <<EOF
+        mysql_execute "mysql" "root" "" "--binary-mode" <<EOF
 -- create root@localhost user for local admin access
 -- create user 'root'@'localhost' ${epassword:+identified by '${epassword}'};
 -- grant all on *.* to 'root'@'localhost' with grant option;

--- a/10.3/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.3/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -508,8 +508,8 @@ mysql_execute_print_output() {
     # Obtain the command specified via stdin
     local mysql_cmd
     mysql_cmd="$(</dev/stdin)"
-    MYSQL_PWD="${pass}" debug "Executing SQL command:\n$mysql_cmd"
-    "$DB_BIN_DIR/mysql" "${args[@]}" <<<"$mysql_cmd"
+    debug "Executing SQL command:\n$mysql_cmd"
+    MYSQL_PWD="${pass}" "$DB_BIN_DIR/mysql" "${args[@]}" <<<"$mysql_cmd"
 }
 
 ########################

--- a/10.4/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.4/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -508,8 +508,8 @@ mysql_execute_print_output() {
     # Obtain the command specified via stdin
     local mysql_cmd
     mysql_cmd="$(</dev/stdin)"
-    MYSQL_PWD="${pass}" debug "Executing SQL command:\n$mysql_cmd"
-    "$DB_BIN_DIR/mysql" "${args[@]}" <<<"$mysql_cmd"
+    debug "Executing SQL command:\n$mysql_cmd"
+    MYSQL_PWD="${pass}" "$DB_BIN_DIR/mysql" "${args[@]}" <<<"$mysql_cmd"
 }
 
 ########################

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -508,8 +508,8 @@ mysql_execute_print_output() {
     # Obtain the command specified via stdin
     local mysql_cmd
     mysql_cmd="$(</dev/stdin)"
-    MYSQL_PWD="${pass}" debug "Executing SQL command:\n$mysql_cmd"
-    "$DB_BIN_DIR/mysql" "${args[@]}" <<<"$mysql_cmd"
+    debug "Executing SQL command:\n$mysql_cmd"
+    MYSQL_PWD="${pass}" "$DB_BIN_DIR/mysql" "${args[@]}" <<<"$mysql_cmd"
 }
 
 ########################

--- a/10.6/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/10.6/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -508,8 +508,8 @@ mysql_execute_print_output() {
     # Obtain the command specified via stdin
     local mysql_cmd
     mysql_cmd="$(</dev/stdin)"
-    MYSQL_PWD="${pass}" debug "Executing SQL command:\n$mysql_cmd"
-    "$DB_BIN_DIR/mysql" "${args[@]}" <<<"$mysql_cmd"
+    debug "Executing SQL command:\n$mysql_cmd"
+    MYSQL_PWD="${pass}" "$DB_BIN_DIR/mysql" "${args[@]}" <<<"$mysql_cmd"
 }
 
 ########################


### PR DESCRIPTION
**Description of the change**

This allows users to choose any password, quotes, any language, backslashes even new lines.

Removes special handling of mysql.user view that isn't needed any more.

**Benefits**

Users will have less problems with passwords that are not accepted.

**Possible drawbacks**

Users may need to appreciate that the complex password they set needs to be handled correctly in all other contexts correctly.

**Applicable issues**

- #204
- #250 (partial)

**Additional information**

Remove the limitation on backslash_password_error to allow all passwords
to be used. The ways this is achieved is:
* adding the function mysql_sql_escape_string_literal which escapes $1
  as if this is ending up inside a single quoted string literal.
* using --binary-mode on mysql to ensure that any use characters are
  used as is
* Removing NO_BACKSLASH_ESCAPES from the sql_mode (for the session). This is the default
  but for any reason a user may have it in their configuration file.
* Passing the password to mysql using the env variable $MYSQL_PWD
  so that its tolerant of the ambiguities of command line parsing of
  complex strings.
* mysql_upgrade was started using --skip-grant-tables. This should
  help address #250, but there was an underlying problem about passing
  the env $MYSQL_PWD through that I didn't get to the bottom of.

Closes #204

Other fixes included because they would massively conflict:

* Remove "FLUSH PRIVILEGES". This is never needed on any user
  modification SQL. Its only needed if underlying tables are changed.
* ${password:+identied by $password} bash syntax used rather than
  subshell. This triggered the shellcheck (hence
https://github.com/koalaman/shellcheck/issues/2383) and the exemption.
* Remove MariaDB mysql.user alter view code. Per docs
  (https://mariadb.com/kb/en/mysqluser-table/) from 10.4.13 there is
  a mariadb.sys user that owns this table. Even if upgrading from
  a datadir before this, the mysql_upgrade will change the owner
  of this view. So nothing special is needed any more.
* shellcheck disable=SC2153 on line 28 for $DB_EXTRA_FLAGS

Tests:

$ podman run --rm --name bnmariadb10.6 -e MARIADB_REPLICATION_MODE=master -e MARIADB_REPLICATION_USER=smith -e MARIADB_REPLICATION_PASSWORD=$'a\\ b" c' -e MARIADB_ROOT_PASSWORD=$'a\n \' \nb' -e MARIADB_USER=sandy -e MARIADB_PASSWORD=$'\n\'\\aa-\x09-zz"_%\n' -e BITNAMI_DEBUG=true   bitnami:10.6

$ podman exec --env MYSQL_PWD=$'a\\ b" c' bnmariadb10.6   mysql -u smith -e 'select current_user(); show grants;'
current_user()
smith@%
Grants for smith@%
GRANT REPLICATION SLAVE ON *.* TO `smith`@`%` IDENTIFIED BY PASSWORD '*E378A1747A212A634186FAA24EBA4C84243B42EC' WITH GRANT OPTION

$ podman exec --env MYSQL_PWD=$'a\n \' \nb'  bnmariadb10.6   mysql -u root -e 'select current_user(); show grants;'
current_user()
root@%
Grants for root@%
GRANT ALL PRIVILEGES ON *.* TO `root`@`%` IDENTIFIED BY PASSWORD '*357E0D70A4E9EAA7D30B087BBA4A4A34F060ECB2' WITH GRANT OPTION

$ podman exec --env MYSQL_PWD=$'\n\'\\aa-\x09-zz"_%\n'   bnmariadb10.6   mysql -u sandy -e 'select current_user(); show grants;'
current_user()
sandy@%
Grants for sandy@%
GRANT USAGE ON *.* TO `sandy`@`%` IDENTIFIED BY PASSWORD '*845F5E8EBBFF983DE9BA0857D2C662B8E0BA5A19'
