### PR TITLE
BITNAMI_DEBUG=yes, good for log, not debug_execute

### DIFF
--- a/10.2/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
+++ b/10.2/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
@@ -333,7 +333,7 @@ convert_to_mb() {
 #   None
 #########################
 debug_execute() {
-    if ${BITNAMI_DEBUG:-false}; then
+    if is_boolean_yes "${BITNAMI_DEBUG:-false}"; then
         "$@"
     else
         "$@" >/dev/null 2>&1

--- a/10.3/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
+++ b/10.3/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
@@ -333,7 +333,7 @@ convert_to_mb() {
 #   None
 #########################
 debug_execute() {
-    if ${BITNAMI_DEBUG:-false}; then
+    if is_boolean_yes "${BITNAMI_DEBUG:-false}"; then
         "$@"
     else
         "$@" >/dev/null 2>&1

--- a/10.4/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
+++ b/10.4/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
@@ -333,7 +333,7 @@ convert_to_mb() {
 #   None
 #########################
 debug_execute() {
-    if ${BITNAMI_DEBUG:-false}; then
+    if is_boolean_yes "${BITNAMI_DEBUG:-false}"; then
         "$@"
     else
         "$@" >/dev/null 2>&1

--- a/10.5/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
+++ b/10.5/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
@@ -333,7 +333,7 @@ convert_to_mb() {
 #   None
 #########################
 debug_execute() {
-    if ${BITNAMI_DEBUG:-false}; then
+    if is_boolean_yes "${BITNAMI_DEBUG:-false}"; then
         "$@"
     else
         "$@" >/dev/null 2>&1

--- a/10.6/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
+++ b/10.6/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
@@ -333,7 +333,7 @@ convert_to_mb() {
 #   None
 #########################
 debug_execute() {
-    if ${BITNAMI_DEBUG:-false}; then
+    if is_boolean_yes "${BITNAMI_DEBUG:-false}"; then
         "$@"
     else
         "$@" >/dev/null 2>&1


### PR DESCRIPTION
While the log messages correctly handle BITNAMI_DEBUG=yes,
debug_execute, true to its name, actually executes it, $BITNAMI_DEBUG.

While the BITNAMI_DEBUG=true, handles the true return code correctly.
The "yes" version will generate a lot of "y" and does not finish,
significantly hampering debugging efforts.

We use the is_boolean_yes from libvalidations.sh to perform the
validation. As debug_execute is called after the libvalidations.sh is
included, the order of libos.sh vs libvalidations.sh isn't as important.

Rebase of #258 after review coments